### PR TITLE
Add entry templates for common account types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,9 @@ line-length = 100
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "UP", "S", "B", "C4", "PIE", "SIM"]
 
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["S101", "S105", "S106"]  # Allow assert and hardcoded passwords in tests
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-v --cov=kdbxtool --cov-report=term-missing"

--- a/src/kdbxtool/__init__.py
+++ b/src/kdbxtool/__init__.py
@@ -67,6 +67,7 @@ from .security.yubikey import (
     check_slot_configured,
     list_yubikeys,
 )
+from .templates import EntryTemplate, IconId, Templates
 
 __all__ = [
     # Core classes
@@ -85,6 +86,10 @@ __all__ = [
     "MergeMode",
     "MergeResult",
     "DeletedObject",
+    # Entry templates
+    "EntryTemplate",
+    "IconId",
+    "Templates",
     # Keyfile support
     "KeyFileVersion",
     "create_keyfile",

--- a/src/kdbxtool/templates.py
+++ b/src/kdbxtool/templates.py
@@ -1,0 +1,391 @@
+"""Entry templates for common account types.
+
+This module provides typed template classes for creating entries with predefined
+fields and icons. Templates follow KeePass conventions for icon IDs and provide
+full IDE autocompletion for field names.
+
+Example:
+    >>> from kdbxtool import Database, Templates
+    >>> db = Database.create(password="secret")
+    >>> entry = db.root_group.create_entry(
+    ...     title="GitHub",
+    ...     template=Templates.Login(),
+    ...     username="user@example.com",
+    ...     password="secret123",
+    ...     url="https://github.com",
+    ... )
+    >>> entry = db.root_group.create_entry(
+    ...     title="Visa Card",
+    ...     template=Templates.CreditCard(
+    ...         card_number="4111111111111111",
+    ...         expiry_date="12/25",
+    ...         cvv="123",
+    ...     ),
+    ... )
+
+Custom templates can be created by subclassing EntryTemplate:
+    >>> from dataclasses import dataclass
+    >>> from typing import ClassVar
+    >>> from kdbxtool import EntryTemplate, IconId
+    >>>
+    >>> @dataclass
+    ... class VPNConnection(EntryTemplate):
+    ...     _icon_id: ClassVar[int] = IconId.TERMINAL_ENCRYPTED
+    ...     _protected_fields: ClassVar[frozenset[str]] = frozenset({"certificate"})
+    ...
+    ...     server: str | None = None
+    ...     protocol: str = "OpenVPN"
+    ...     certificate: str | None = None
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, fields
+from enum import IntEnum
+from typing import ClassVar
+
+
+class IconId(IntEnum):
+    """KeePass standard icon IDs.
+
+    These correspond to the PwIcon enumeration in KeePass. There are 69
+    standard icons (0-68) built into KeePass/KeePassXC.
+    """
+
+    KEY = 0
+    WORLD = 1
+    WARNING = 2
+    NETWORK_SERVER = 3
+    MARKED_DIRECTORY = 4
+    USER_COMMUNICATION = 5
+    PARTS = 6
+    NOTEPAD = 7
+    WORLD_SOCKET = 8
+    IDENTITY = 9
+    PAPER_READY = 10
+    DIGICAM = 11
+    IR_COMMUNICATION = 12
+    MULTI_KEYS = 13
+    ENERGY = 14
+    SCANNER = 15
+    WORLD_STAR = 16
+    CDROM = 17
+    MONITOR = 18
+    EMAIL = 19
+    CONFIGURATION = 20
+    CLIPBOARD_READY = 21
+    PAPER_NEW = 22
+    SCREEN = 23
+    ENERGY_CAREFUL = 24
+    EMAIL_BOX = 25
+    DISK = 26
+    DRIVE = 27
+    PAPER_Q = 28
+    TERMINAL_ENCRYPTED = 29
+    CONSOLE = 30
+    PRINTER = 31
+    PROGRAM_ICONS = 32
+    RUN = 33
+    SETTINGS = 34
+    WORLD_COMPUTER = 35
+    ARCHIVE = 36
+    HOMEBANKING = 37
+    DRIVE_WINDOWS = 38
+    CLOCK = 39
+    EMAIL_SEARCH = 40
+    PAPER_FLAG = 41
+    MEMORY = 42
+    TRASH_BIN = 43
+    NOTE = 44
+    EXPIRED = 45
+    INFO = 46
+    PACKAGE = 47
+    FOLDER = 48
+    FOLDER_OPEN = 49
+    FOLDER_PACKAGE = 50
+    LOCK_OPEN = 51
+    PAPER_LOCKED = 52
+    CHECKED = 53
+    PEN = 54
+    THUMBNAIL = 55
+    BOOK = 56
+    LIST = 57
+    USER_KEY = 58
+    TOOL = 59
+    HOME = 60
+    STAR = 61
+    TUX = 62
+    FEATHER = 63
+    APPLE = 64
+    WIKI = 65
+    MONEY = 66
+    CERTIFICATE = 67
+    BLACKBERRY = 68
+
+
+@dataclass
+class EntryTemplate:
+    """Base class for entry templates. Subclass to create custom templates.
+
+    Class variables to override:
+        _icon_id: Icon for entries using this template (default: KEY)
+        _include_standard: Whether to populate username/password/url (default: True)
+        _protected_fields: Field names that should be memory-protected
+
+    Example:
+        >>> @dataclass
+        ... class VPNConnection(EntryTemplate):
+        ...     _icon_id: ClassVar[int] = IconId.TERMINAL_ENCRYPTED
+        ...     _protected_fields: ClassVar[frozenset[str]] = frozenset({"certificate"})
+        ...
+        ...     server: str | None = None
+        ...     protocol: str = "OpenVPN"
+        ...     certificate: str | None = None
+        ...
+        >>> entry = group.create_entry(
+        ...     title="Work VPN",
+        ...     template=VPNConnection(server="vpn.company.com"),
+        ... )
+    """
+
+    _icon_id: ClassVar[int] = IconId.KEY
+    _include_standard: ClassVar[bool] = True
+    _protected_fields: ClassVar[frozenset[str]] = frozenset()
+
+    def _get_fields(self) -> dict[str, tuple[str | None, bool]]:
+        """Return template field values with display names and protection status.
+
+        Returns:
+            Dict mapping display name to (value, is_protected) tuple.
+            Display names are derived from field names by replacing underscores
+            with spaces and title-casing.
+        """
+        result: dict[str, tuple[str | None, bool]] = {}
+        for field in fields(self):
+            if field.name.startswith("_"):
+                continue  # Skip class variables
+            value = getattr(self, field.name)
+            display_name = field.name.replace("_", " ").title()
+            is_protected = field.name in self._protected_fields
+            result[display_name] = (value, is_protected)
+        return result
+
+
+# --- Built-in Templates ---
+
+
+@dataclass
+class Login(EntryTemplate):
+    """Standard login entry template.
+
+    Uses standard fields (title, username, password, url) without
+    additional custom fields.
+    """
+
+
+@dataclass
+class CreditCard(EntryTemplate):
+    """Credit card entry template.
+
+    Includes card number, expiry date, CVV, cardholder name, and PIN.
+    Sensitive fields (card_number, cvv, pin) are memory-protected.
+    Does not use standard username/password fields.
+    """
+
+    _icon_id: ClassVar[int] = IconId.MONEY
+    _include_standard: ClassVar[bool] = False
+    _protected_fields: ClassVar[frozenset[str]] = frozenset({"card_number", "cvv", "pin"})
+
+    card_number: str | None = None
+    expiry_date: str | None = None
+    cvv: str | None = None
+    cardholder_name: str | None = None
+    pin: str | None = None
+
+
+@dataclass
+class SecureNote(EntryTemplate):
+    """Secure note entry template.
+
+    For storing text without standard credential fields.
+    Use the notes parameter in create_entry() for content.
+    """
+
+    _icon_id: ClassVar[int] = IconId.NOTE
+    _include_standard: ClassVar[bool] = False
+
+
+@dataclass
+class Identity(EntryTemplate):
+    """Identity/personal information entry template.
+
+    Includes name, contact, and address fields.
+    Does not use standard username/password fields.
+    """
+
+    _icon_id: ClassVar[int] = IconId.IDENTITY
+    _include_standard: ClassVar[bool] = False
+
+    first_name: str | None = None
+    last_name: str | None = None
+    email: str | None = None
+    phone: str | None = None
+    address: str | None = None
+    city: str | None = None
+    state: str | None = None
+    postal_code: str | None = None
+    country: str | None = None
+
+
+@dataclass
+class BankAccount(EntryTemplate):
+    """Bank account entry template.
+
+    Includes account details and routing information.
+    Sensitive fields (account_number, iban, pin) are memory-protected.
+    Does not use standard username/password fields.
+    """
+
+    _icon_id: ClassVar[int] = IconId.HOMEBANKING
+    _include_standard: ClassVar[bool] = False
+    _protected_fields: ClassVar[frozenset[str]] = frozenset({"account_number", "iban", "pin"})
+
+    bank_name: str | None = None
+    account_type: str | None = None
+    account_number: str | None = None
+    routing_number: str | None = None
+    swift_bic: str | None = None
+    iban: str | None = None
+    pin: str | None = None
+
+
+@dataclass
+class Server(EntryTemplate):
+    """Server/SSH entry template.
+
+    Includes hostname, port, and SSH key fields.
+    Uses standard username/password fields for credentials.
+    SSH key is memory-protected.
+    """
+
+    _icon_id: ClassVar[int] = IconId.CONSOLE
+    _protected_fields: ClassVar[frozenset[str]] = frozenset({"ssh_key"})
+
+    hostname: str | None = None
+    port: str = "22"
+    ssh_key: str | None = None
+
+
+@dataclass
+class WirelessRouter(EntryTemplate):
+    """Wireless router entry template.
+
+    Includes SSID, security type, and admin credentials.
+    Admin password is memory-protected.
+    """
+
+    _icon_id: ClassVar[int] = IconId.IR_COMMUNICATION
+    _protected_fields: ClassVar[frozenset[str]] = frozenset({"admin_password"})
+
+    ssid: str | None = None
+    security_type: str = "WPA2"
+    admin_url: str | None = None
+    admin_username: str | None = None
+    admin_password: str | None = None
+
+
+@dataclass
+class Email(EntryTemplate):
+    """Email account entry template.
+
+    Includes email address and server settings.
+    Uses standard username/password fields for credentials.
+    """
+
+    _icon_id: ClassVar[int] = IconId.EMAIL
+
+    email_address: str | None = None
+    imap_server: str | None = None
+    imap_port: str = "993"
+    smtp_server: str | None = None
+    smtp_port: str = "587"
+
+
+@dataclass
+class SoftwareLicense(EntryTemplate):
+    """Software license entry template.
+
+    Includes license key and registration information.
+    License key is memory-protected.
+    Does not use standard username/password fields.
+    """
+
+    _icon_id: ClassVar[int] = IconId.PACKAGE
+    _include_standard: ClassVar[bool] = False
+    _protected_fields: ClassVar[frozenset[str]] = frozenset({"license_key"})
+
+    license_key: str | None = None
+    registered_email: str | None = None
+    registered_name: str | None = None
+    purchase_date: str | None = None
+    download_url: str | None = None
+
+
+@dataclass
+class DatabaseConnection(EntryTemplate):
+    """Database connection entry template.
+
+    Includes database type, host, port, and connection details.
+    Connection string is memory-protected.
+    Uses standard username/password fields for credentials.
+    """
+
+    _icon_id: ClassVar[int] = IconId.DRIVE
+    _protected_fields: ClassVar[frozenset[str]] = frozenset({"connection_string"})
+
+    database_type: str = "PostgreSQL"
+    host: str | None = None
+    port: str = "5432"
+    database_name: str | None = None
+    connection_string: str | None = None
+
+
+class Templates:
+    """Namespace containing all built-in entry templates.
+
+    Provides discoverability via IDE autocompletion.
+
+    Usage:
+        >>> from kdbxtool import Templates
+        >>>
+        >>> entry = group.create_entry(
+        ...     title="My Card",
+        ...     template=Templates.CreditCard(
+        ...         card_number="4111111111111111",
+        ...         cvv="123",
+        ...     ),
+        ... )
+
+    Available templates:
+        - Login: Standard login (username, password, url)
+        - CreditCard: Card number, expiry, CVV, cardholder, PIN
+        - SecureNote: Notes-only entry
+        - Identity: Personal information (name, address, etc.)
+        - BankAccount: Account and routing numbers
+        - Server: Hostname, port, SSH key
+        - WirelessRouter: SSID, security type, admin credentials
+        - Email: Email address and server settings
+        - SoftwareLicense: License key and registration info
+        - Database: Database connection details
+    """
+
+    Login = Login
+    CreditCard = CreditCard
+    SecureNote = SecureNote
+    Identity = Identity
+    BankAccount = BankAccount
+    Server = Server
+    WirelessRouter = WirelessRouter
+    Email = Email
+    SoftwareLicense = SoftwareLicense
+    Database = DatabaseConnection

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,346 @@
+"""Tests for entry templates."""
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+import pytest
+
+from kdbxtool import (
+    Database,
+    EntryTemplate,
+    IconId,
+    Templates,
+)
+
+
+class TestIconId:
+    """Tests for IconId enum."""
+
+    def test_icon_values(self) -> None:
+        """Test that icon IDs have expected values."""
+        assert int(IconId.KEY) == 0
+        assert int(IconId.WORLD) == 1
+        assert int(IconId.MONEY) == 66
+        assert int(IconId.BLACKBERRY) == 68
+
+    def test_icon_count(self) -> None:
+        """Test that all 69 standard KeePass icons are defined."""
+        # KeePass has icons 0-68 = 69 total
+        assert len(IconId) == 69
+
+    def test_icon_is_int(self) -> None:
+        """Test that IconId values can be used as integers."""
+        icon = IconId.EMAIL
+        assert isinstance(icon, int)
+        assert icon == 19
+
+
+class TestEntryTemplateBase:
+    """Tests for EntryTemplate base class."""
+
+    def test_default_values(self) -> None:
+        """Test base class default values."""
+        template = EntryTemplate()
+        assert template._icon_id == IconId.KEY
+        assert template._include_standard is True
+        assert template._protected_fields == frozenset()
+
+    def test_get_fields_empty(self) -> None:
+        """Test _get_fields on base class returns empty dict."""
+        template = EntryTemplate()
+        assert template._get_fields() == {}
+
+
+class TestBuiltInTemplates:
+    """Tests for built-in entry templates."""
+
+    def test_login_template(self) -> None:
+        """Test Login template attributes."""
+        t = Templates.Login()
+        assert t._icon_id == IconId.KEY
+        assert t._include_standard is True
+        assert t._get_fields() == {}
+
+    def test_credit_card_template(self) -> None:
+        """Test CreditCard template attributes."""
+        t = Templates.CreditCard()
+        assert t._icon_id == IconId.MONEY
+        assert t._include_standard is False
+        # Protected fields
+        assert "card_number" in t._protected_fields
+        assert "cvv" in t._protected_fields
+        assert "pin" in t._protected_fields
+
+    def test_credit_card_fields(self) -> None:
+        """Test CreditCard field population."""
+        t = Templates.CreditCard(
+            card_number="4111111111111111",
+            cvv="123",
+        )
+        fields = t._get_fields()
+        assert fields["Card Number"] == ("4111111111111111", True)
+        assert fields["Cvv"] == ("123", True)
+
+    def test_secure_note_template(self) -> None:
+        """Test SecureNote template attributes."""
+        t = Templates.SecureNote()
+        assert t._icon_id == IconId.NOTE
+        assert t._include_standard is False
+        assert t._get_fields() == {}
+
+    def test_identity_template(self) -> None:
+        """Test Identity template attributes."""
+        t = Templates.Identity(first_name="John", email="john@example.com")
+        assert t._icon_id == IconId.IDENTITY
+        assert t._include_standard is False
+        fields = t._get_fields()
+        assert fields["First Name"] == ("John", False)
+        assert fields["Email"] == ("john@example.com", False)
+
+    def test_bank_account_template(self) -> None:
+        """Test BankAccount template attributes."""
+        t = Templates.BankAccount()
+        assert t._icon_id == IconId.HOMEBANKING
+        assert t._include_standard is False
+        assert "account_number" in t._protected_fields
+        assert "iban" in t._protected_fields
+
+    def test_server_template(self) -> None:
+        """Test Server template attributes."""
+        t = Templates.Server(hostname="192.168.1.1")
+        assert t._icon_id == IconId.CONSOLE
+        assert t._include_standard is True
+        assert "ssh_key" in t._protected_fields
+        # Check default value
+        assert t.port == "22"
+        fields = t._get_fields()
+        assert fields["Hostname"] == ("192.168.1.1", False)
+        assert fields["Port"] == ("22", False)
+
+    def test_wireless_router_template(self) -> None:
+        """Test WirelessRouter template attributes."""
+        t = Templates.WirelessRouter(ssid="MyNetwork")
+        assert t._icon_id == IconId.IR_COMMUNICATION
+        assert t.security_type == "WPA2"
+
+    def test_email_template(self) -> None:
+        """Test Email template attributes."""
+        t = Templates.Email(email_address="user@example.com")
+        assert t._icon_id == IconId.EMAIL
+        assert t._include_standard is True
+        assert t.imap_port == "993"
+        assert t.smtp_port == "587"
+
+    def test_software_license_template(self) -> None:
+        """Test SoftwareLicense template attributes."""
+        t = Templates.SoftwareLicense(license_key="XXXX-XXXX")
+        assert t._icon_id == IconId.PACKAGE
+        assert t._include_standard is False
+        assert "license_key" in t._protected_fields
+
+    def test_database_template(self) -> None:
+        """Test Database template attributes."""
+        t = Templates.Database(host="localhost")
+        assert t._icon_id == IconId.DRIVE
+        assert t._include_standard is True
+        assert t.database_type == "PostgreSQL"
+        assert t.port == "5432"
+
+
+class TestCreateEntryWithTemplate:
+    """Tests for creating entries using templates."""
+
+    @pytest.fixture
+    def db(self) -> Database:
+        """Create a test database."""
+        return Database.create(password="test")
+
+    def test_create_entry_no_template(self, db: Database) -> None:
+        """Test creating entry without template (standard behavior)."""
+        entry = db.root_group.create_entry(
+            title="GitHub",
+            username="user@example.com",
+            password="secret123",
+            url="https://github.com",
+        )
+        assert entry.title == "GitHub"
+        assert entry.username == "user@example.com"
+        assert entry.password == "secret123"
+        assert entry.url == "https://github.com"
+
+    def test_create_entry_with_login_template(self, db: Database) -> None:
+        """Test creating entry with Login template."""
+        entry = db.root_group.create_entry(
+            title="Gmail",
+            username="user@gmail.com",
+            password="pass123",
+            url="https://gmail.com",
+            template=Templates.Login(),
+        )
+        assert entry.title == "Gmail"
+        assert entry.username == "user@gmail.com"
+        assert entry.password == "pass123"
+        assert entry.icon_id == str(IconId.KEY)
+
+    def test_create_entry_with_credit_card_template(self, db: Database) -> None:
+        """Test creating entry with CreditCard template."""
+        entry = db.root_group.create_entry(
+            title="My Visa",
+            template=Templates.CreditCard(
+                card_number="4111111111111111",
+                expiry_date="12/25",
+                cvv="123",
+                cardholder_name="John Doe",
+            ),
+        )
+        assert entry.title == "My Visa"
+        assert entry.icon_id == str(IconId.MONEY)
+        # Standard fields should not be set (include_standard=False)
+        assert entry.username is None
+        assert entry.password is None
+        # Custom fields should be populated
+        assert entry.strings["Card Number"].value == "4111111111111111"
+        assert entry.strings["Expiry Date"].value == "12/25"
+        assert entry.strings["Cvv"].value == "123"
+        assert entry.strings["Cardholder Name"].value == "John Doe"
+        # Protected fields should be marked as such
+        assert entry.strings["Card Number"].protected is True
+        assert entry.strings["Cvv"].protected is True
+
+    def test_create_entry_with_server_template(self, db: Database) -> None:
+        """Test creating entry with Server template (include_standard=True)."""
+        entry = db.root_group.create_entry(
+            title="prod-server",
+            username="admin",
+            password="secret",
+            template=Templates.Server(
+                hostname="192.168.1.1",
+                port="2222",
+                ssh_key="-----BEGIN RSA PRIVATE KEY-----",
+            ),
+        )
+        assert entry.title == "prod-server"
+        assert entry.username == "admin"
+        assert entry.password == "secret"
+        assert entry.icon_id == str(IconId.CONSOLE)
+        assert entry.strings["Hostname"].value == "192.168.1.1"
+        assert entry.strings["Port"].value == "2222"
+        assert entry.strings["Ssh Key"].value == "-----BEGIN RSA PRIVATE KEY-----"
+        assert entry.strings["Ssh Key"].protected is True
+
+    def test_create_entry_template_defaults(self, db: Database) -> None:
+        """Test that template field defaults are applied."""
+        entry = db.root_group.create_entry(
+            title="my-server",
+            template=Templates.Server(hostname="10.0.0.1"),
+        )
+        # Port should have default value from template
+        assert entry.strings["Port"].value == "22"
+
+    def test_create_entry_secure_note(self, db: Database) -> None:
+        """Test creating a secure note."""
+        entry = db.root_group.create_entry(
+            title="My Secret",
+            notes="This is confidential information.",
+            template=Templates.SecureNote(),
+        )
+        assert entry.title == "My Secret"
+        assert entry.notes == "This is confidential information."
+        assert entry.icon_id == str(IconId.NOTE)
+        # No standard fields
+        assert entry.username is None
+        assert entry.password is None
+
+    def test_create_entry_identity(self, db: Database) -> None:
+        """Test creating an identity entry."""
+        entry = db.root_group.create_entry(
+            title="Personal",
+            template=Templates.Identity(
+                first_name="John",
+                last_name="Doe",
+                email="john@example.com",
+                phone="555-1234",
+            ),
+        )
+        assert entry.title == "Personal"
+        assert entry.strings["First Name"].value == "John"
+        assert entry.strings["Last Name"].value == "Doe"
+        assert entry.strings["Email"].value == "john@example.com"
+        assert entry.strings["Phone"].value == "555-1234"
+
+    def test_none_fields_not_added(self, db: Database) -> None:
+        """Test that None fields are not added to entry."""
+        entry = db.root_group.create_entry(
+            title="Partial Card",
+            template=Templates.CreditCard(
+                card_number="1234",
+                # other fields left as None
+            ),
+        )
+        assert "Card Number" in entry.strings
+        assert "Expiry Date" not in entry.strings
+        assert "Cvv" not in entry.strings
+
+
+class TestCustomTemplate:
+    """Tests for creating and using custom templates."""
+
+    @pytest.fixture
+    def db(self) -> Database:
+        """Create a test database."""
+        return Database.create(password="test")
+
+    def test_custom_template(self, db: Database) -> None:
+        """Test creating entry with a custom template."""
+
+        @dataclass
+        class VPNConnection(EntryTemplate):
+            _icon_id: ClassVar[int] = IconId.TERMINAL_ENCRYPTED
+            _protected_fields: ClassVar[frozenset[str]] = frozenset({"certificate"})
+
+            server: str | None = None
+            protocol: str = "OpenVPN"
+            certificate: str | None = None
+
+        entry = db.root_group.create_entry(
+            title="Work VPN",
+            username="johnd",
+            password="vpnpass",
+            template=VPNConnection(
+                server="vpn.company.com",
+                certificate="-----BEGIN CERTIFICATE-----",
+            ),
+        )
+
+        assert entry.title == "Work VPN"
+        assert entry.username == "johnd"  # include_standard=True by default
+        assert entry.icon_id == str(IconId.TERMINAL_ENCRYPTED)
+        assert entry.strings["Server"].value == "vpn.company.com"
+        assert entry.strings["Protocol"].value == "OpenVPN"  # default
+        assert entry.strings["Certificate"].value == "-----BEGIN CERTIFICATE-----"
+        assert entry.strings["Certificate"].protected is True
+
+    def test_custom_template_no_standard_fields(self, db: Database) -> None:
+        """Test custom template that excludes standard fields."""
+
+        @dataclass
+        class ApiKey(EntryTemplate):
+            _icon_id: ClassVar[int] = IconId.KEY
+            _include_standard: ClassVar[bool] = False
+            _protected_fields: ClassVar[frozenset[str]] = frozenset({"api_key"})
+
+            api_key: str | None = None
+            environment: str = "production"
+
+        entry = db.root_group.create_entry(
+            title="Stripe API",
+            username="ignored",  # Should be ignored
+            password="also_ignored",  # Should be ignored
+            template=ApiKey(api_key="sk_live_xxxxx"),
+        )
+
+        assert entry.title == "Stripe API"
+        assert entry.username is None  # Not set because include_standard=False
+        assert entry.password is None
+        assert entry.strings["Api Key"].value == "sk_live_xxxxx"
+        assert entry.strings["Environment"].value == "production"


### PR DESCRIPTION
## Summary
Implements typed template classes for entry creation with full IDE autocompletion and type safety.

**Key changes:**
- `EntryTemplate` base class for custom templates (subclass to create your own)
- Built-in templates via `Templates` namespace: Login, CreditCard, SecureNote, Identity, BankAccount, Server, WirelessRouter, Email, SoftwareLicense, Database
- `IconId` enum with all 69 KeePass standard icons (PwIcon 0-68)
- Templates carry their field values as typed dataclass fields
- Protected fields via `_protected_fields` ClassVar
- `_include_standard` flag controls whether username/password/url are populated

## Usage

```python
from kdbxtool import Database, Templates

db = Database.create(password="secret")

# Built-in template with IDE completion
entry = db.root_group.create_entry(
    title="My Visa",
    template=Templates.CreditCard(
        card_number="4111111111111111",
        expiry_date="12/25",
        cvv="123",
    ),
)

# Custom template
from dataclasses import dataclass
from typing import ClassVar
from kdbxtool import EntryTemplate, IconId

@dataclass
class VPNConnection(EntryTemplate):
    _icon_id: ClassVar[int] = IconId.TERMINAL_ENCRYPTED
    _protected_fields: ClassVar[frozenset[str]] = frozenset({"certificate"})

    server: str | None = None
    protocol: str = "OpenVPN"
    certificate: str | None = None

entry = db.root_group.create_entry(
    title="Work VPN",
    template=VPNConnection(server="vpn.company.com"),
)
```

## Test plan
- [x] 26 template tests covering all built-in templates and custom templates
- [x] All 702 existing tests pass
- [x] mypy --strict passes
- [x] ruff check passes

Closes #58