### PR TITLE
feat: yubikey mock and touch prompting

### DIFF
--- a/src/kdbxtool/__init__.py
+++ b/src/kdbxtool/__init__.py
@@ -22,11 +22,12 @@ Example:
     db.save()
 """
 
-__version__ = "0.1.0"
+__version__ = "0.1.5"
 
 from .database import Database, DatabaseSettings
 from .exceptions import (
     AuthenticationError,
+    ChallengeResponseError,
     CorruptedDataError,
     CredentialError,
     CryptoError,
@@ -62,6 +63,7 @@ from .security.keyfile import (
     create_keyfile_bytes,
     parse_keyfile,
 )
+from .security.challenge_response import ChallengeResponseProvider
 from .security.yubikey import (
     YubiKeyConfig,
     check_slot_configured,
@@ -95,7 +97,8 @@ __all__ = [
     "create_keyfile",
     "create_keyfile_bytes",
     "parse_keyfile",
-    # YubiKey support
+    # Challenge-response / YubiKey support
+    "ChallengeResponseProvider",
     "YubiKeyConfig",
     "check_slot_configured",
     "list_yubikeys",
@@ -116,6 +119,7 @@ __all__ = [
     "InvalidKeyFileError",
     "MergeError",
     "MissingCredentialsError",
+    "ChallengeResponseError",
     "DatabaseError",
     "EntryNotFoundError",
     "GroupNotFoundError",

--- a/src/kdbxtool/exceptions.py
+++ b/src/kdbxtool/exceptions.py
@@ -19,11 +19,12 @@ Exception Hierarchy:
     │   ├── InvalidPasswordError
     │   ├── InvalidKeyFileError
     │   ├── MissingCredentialsError
-    │   └── YubiKeyError
-    │       ├── YubiKeyNotFoundError
-    │       ├── YubiKeySlotError
-    │       ├── YubiKeyTimeoutError
-    │       └── YubiKeyNotAvailableError
+    │   └── ChallengeResponseError
+    │       └── YubiKeyError
+    │           ├── YubiKeyNotFoundError
+    │           ├── YubiKeySlotError
+    │           ├── YubiKeyTimeoutError
+    │           └── YubiKeyNotAvailableError
     └── DatabaseError
         ├── EntryNotFoundError
         └── GroupNotFoundError
@@ -197,10 +198,23 @@ class MissingCredentialsError(CredentialError):
         super().__init__("At least one credential (password or keyfile) is required")
 
 
+# --- Challenge-Response Errors ---
+
+
+class ChallengeResponseError(CredentialError):
+    """Error during challenge-response authentication.
+
+    Base class for challenge-response related errors. These occur during
+    hardware-backed authentication operations (e.g., YubiKey, smart cards).
+
+    Implementations may raise subclasses with device-specific details.
+    """
+
+
 # --- YubiKey Errors ---
 
 
-class YubiKeyError(CredentialError):
+class YubiKeyError(ChallengeResponseError):
     """Error communicating with YubiKey.
 
     Base class for YubiKey-related errors. These occur during
@@ -238,10 +252,9 @@ class YubiKeyTimeoutError(YubiKeyError):
     was required but not received within the timeout period.
     """
 
-    def __init__(self, timeout_seconds: float = 15.0) -> None:
-        self.timeout_seconds = timeout_seconds
+    def __init__(self) -> None:
         super().__init__(
-            f"YubiKey operation timed out after {timeout_seconds}s. "
+            "YubiKey operation timed out. "
             "Touch may be required - try again and press the YubiKey button."
         )
 

--- a/src/kdbxtool/security/__init__.py
+++ b/src/kdbxtool/security/__init__.py
@@ -4,11 +4,12 @@ This module contains all security-sensitive code including:
 - Secure memory handling (SecureBytes)
 - Cryptographic operations
 - Key derivation functions
-- YubiKey challenge-response support
+- Challenge-response authentication (YubiKey support)
 
 All code in this module should be audited carefully.
 """
 
+from .challenge_response import ChallengeResponseProvider
 from .crypto import (
     Cipher,
     CipherContext,
@@ -37,7 +38,9 @@ from .keyfile import (
 from .memory import SecureBytes
 from .yubikey import (
     HMAC_SHA1_RESPONSE_SIZE,
-    YUBIKEY_AVAILABLE,
+    YUBIKEY_HARDWARE_AVAILABLE,
+    HardwareYubiKey,
+    MockYubiKey,
     YubiKeyConfig,
     check_slot_configured,
     compute_challenge_response,
@@ -69,9 +72,12 @@ __all__ = [
     "create_keyfile",
     "create_keyfile_bytes",
     "parse_keyfile",
-    # YubiKey
+    # YubiKey / Challenge-Response
     "HMAC_SHA1_RESPONSE_SIZE",
-    "YUBIKEY_AVAILABLE",
+    "YUBIKEY_HARDWARE_AVAILABLE",
+    "ChallengeResponseProvider",
+    "HardwareYubiKey",
+    "MockYubiKey",
     "YubiKeyConfig",
     "check_slot_configured",
     "compute_challenge_response",

--- a/src/kdbxtool/security/challenge_response.py
+++ b/src/kdbxtool/security/challenge_response.py
@@ -1,0 +1,69 @@
+"""Abstract challenge-response authentication interface.
+
+This module provides the abstract base class for challenge-response
+authentication providers. Implementations include:
+- HardwareYubiKey: Physical YubiKey hardware via yubikey-manager
+- MockYubiKey: Software implementation for testing
+
+The ChallengeResponseProvider ABC allows different hardware tokens
+to be used interchangeably for database authentication.
+
+Example:
+    >>> from kdbxtool.security.yubikey import HardwareYubiKey
+    >>> provider = HardwareYubiKey(slot=2)
+    >>> db = Database.open("vault.kdbx", password="secret",
+    ...                    challenge_response_provider=provider)
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .memory import SecureBytes
+
+
+class ChallengeResponseProvider(ABC):
+    """Abstract base class for HMAC-SHA1 challenge-response providers.
+
+    This interface allows different implementations of challenge-response
+    authentication to be used interchangeably:
+    - HardwareYubiKey: Uses physical YubiKey hardware
+    - MockYubiKey: Software implementation for testing
+
+    Implementations must provide challenge_response() which computes an
+    HMAC-SHA1 response for a given challenge.
+
+    Example:
+        >>> # Using hardware YubiKey
+        >>> from kdbxtool.security.yubikey import HardwareYubiKey
+        >>> provider = HardwareYubiKey(slot=2)
+        >>> db = Database.open("vault.kdbx", password="secret",
+        ...                    challenge_response_provider=provider)
+        >>>
+        >>> # Using mock for testing
+        >>> from kdbxtool.security.yubikey import MockYubiKey
+        >>> provider = MockYubiKey.with_zero_secret(slot=1)
+        >>> db = Database.open_bytes(data, password="test",
+        ...                          challenge_response_provider=provider)
+    """
+
+    @abstractmethod
+    def challenge_response(
+        self,
+        challenge: bytes,
+    ) -> SecureBytes:
+        """Compute HMAC-SHA1 response for the given challenge.
+
+        Args:
+            challenge: Challenge bytes (e.g., 32-byte KDF salt from database)
+
+        Returns:
+            20-byte HMAC-SHA1 response wrapped in SecureBytes
+
+        Raises:
+            ChallengeResponseError: If the operation fails. Implementations
+                may raise subclasses with device-specific details.
+        """
+        ...

--- a/src/kdbxtool/security/kdf.py
+++ b/src/kdbxtool/security/kdf.py
@@ -179,18 +179,21 @@ class Argon2Config:
         cls,
         salt: bytes | None = None,
         variant: KdfType = KdfType.ARGON2D,
+        iterations: int = 10,
     ) -> Argon2Config:
         """Create configuration for high-security applications.
 
         Use for sensitive data where longer unlock times are acceptable.
         Provides stronger protection against brute-force attacks.
 
-        Parameters: 256 MiB memory, 10 iterations, 4 parallelism
+        Parameters: 256 MiB memory, 10 iterations (configurable), 4 parallelism
 
         Args:
             salt: Optional salt (32 random bytes generated if not provided)
             variant: Argon2 variant (ARGON2D or ARGON2ID). Default is ARGON2D
                 which provides better GPU resistance for local password databases.
+            iterations: Number of iterations (default: 10). Higher values increase
+                security but also unlock time.
 
         Returns:
             Argon2Config with high security parameters
@@ -201,7 +204,7 @@ class Argon2Config:
             salt = os.urandom(32)
         return cls(
             memory_kib=256 * 1024,  # 256 MiB
-            iterations=10,
+            iterations=iterations,
             parallelism=4,
             salt=salt,
             variant=variant,

--- a/src/kdbxtool/security/yubikey.py
+++ b/src/kdbxtool/security/yubikey.py
@@ -12,7 +12,16 @@ This provides hardware-backed security: the database cannot be decrypted
 without physical access to the configured YubiKey, even if the password
 is known.
 
-Requirements:
+Provider Architecture:
+    ChallengeResponseProvider is an abstract base class that defines the
+    interface for challenge-response operations. Two implementations are provided:
+    - HardwareYubiKey: Uses physical YubiKey hardware via yubikey-manager
+    - MockYubiKey: Software implementation for testing without hardware
+
+    Pass a provider to Database.open(), Database.save(), etc. via the
+    `challenge_response_provider` parameter.
+
+Requirements (for HardwareYubiKey):
     - yubikey-manager package (install with: pip install kdbxtool[yubikey])
     - YubiKey 2.2+ with HMAC-SHA1 configured in slot 1 or 2
     - Linux: udev rules for YubiKey access (usually automatic)
@@ -23,10 +32,17 @@ Security Notes:
     - The YubiKey's HMAC secret is never extracted or stored
     - Response is wrapped in SecureBytes for automatic zeroization
     - YubiKey loss = data loss (unless backup credentials exist)
+
+Testing Notes:
+    - Use MockYubiKey for testing without hardware
+    - Common test secrets:
+        - ZERO_SECRET: 20 zero bytes (0x00 * 20) - typically slot 1
+        - NUMERIC_SECRET: "12345678901234567890" - typically slot 2
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -38,20 +54,21 @@ from kdbxtool.exceptions import (
     YubiKeyTimeoutError,
 )
 
+from .challenge_response import ChallengeResponseProvider
 from .memory import SecureBytes
 
-# Optional yubikey-manager support
+# Optional yubikey-manager support for hardware YubiKey
 try:
     from ykman.device import list_all_devices  # type: ignore[import-not-found]
     from yubikit.core.otp import OtpConnection  # type: ignore[import-not-found]
-    from yubikit.yubiotp import (  # type: ignore[import-not-found]
-        SLOT,
+    from yubikit.yubiotp import (
+        SLOT,  # type: ignore[import-not-found]
         YubiOtpSession,
     )
 
-    YUBIKEY_AVAILABLE = True
+    YUBIKEY_HARDWARE_AVAILABLE = True
 except ImportError:
-    YUBIKEY_AVAILABLE = False
+    YUBIKEY_HARDWARE_AVAILABLE = False
 
 if TYPE_CHECKING:
     pass
@@ -59,6 +76,16 @@ if TYPE_CHECKING:
 
 # HMAC-SHA1 response is always 20 bytes
 HMAC_SHA1_RESPONSE_SIZE = 20
+
+
+def DEFAULT_TOUCH_CALLBACK() -> None:
+    """Default callback to notify user when YubiKey touch is required.
+
+    Prints a message to stderr (critical user feedback, always visible).
+    """
+    import sys
+
+    print("Touch your YubiKey...", file=sys.stderr)  # noqa: T201
 
 
 @dataclass(frozen=True, slots=True)
@@ -71,20 +98,15 @@ class YubiKeyConfig:
         serial: Optional serial number to select a specific YubiKey when
             multiple devices are connected. If None, uses the first device.
             Use list_yubikeys() to discover available devices and serials.
-        timeout_seconds: Timeout for challenge-response operation in seconds.
-            If touch is required, this is the time to wait for the button press.
     """
 
     slot: int = 2
     serial: int | None = None
-    timeout_seconds: float = 15.0
 
     def __post_init__(self) -> None:
         """Validate configuration."""
         if self.slot not in (1, 2):
             raise ValueError("YubiKey slot must be 1 or 2")
-        if self.timeout_seconds <= 0:
-            raise ValueError("Timeout must be positive")
 
 
 def list_yubikeys() -> list[dict[str, str | int]]:
@@ -98,7 +120,7 @@ def list_yubikeys() -> list[dict[str, str | int]]:
     Raises:
         YubiKeyNotAvailableError: If yubikey-manager is not installed.
     """
-    if not YUBIKEY_AVAILABLE:
+    if not YUBIKEY_HARDWARE_AVAILABLE:
         raise YubiKeyNotAvailableError()
 
     devices = []
@@ -119,6 +141,7 @@ def list_yubikeys() -> list[dict[str, str | int]]:
 def compute_challenge_response(
     challenge: bytes,
     config: YubiKeyConfig | None = None,
+    on_touch_required: Callable[[], None] | None = None,
 ) -> SecureBytes:
     """Send challenge to YubiKey and return HMAC-SHA1 response.
 
@@ -126,11 +149,19 @@ def compute_challenge_response(
     YubiKey and returns the HMAC-SHA1 response. The response is computed
     by the YubiKey hardware using a secret that never leaves the device.
 
+    Note: For new code, prefer using HardwareYubiKey provider directly:
+        provider = HardwareYubiKey(slot=2)
+        response = provider.challenge_response(challenge)
+
     Args:
         challenge: Challenge bytes (32-byte KDF salt from KDBX header).
             Must be at least 1 byte.
         config: Optional YubiKey configuration. If not provided, uses
-            slot 2 with 15 second timeout.
+            default settings (slot 2, first device).
+        on_touch_required: Optional callback invoked when the YubiKey is
+            waiting for touch. This is called at most once per operation.
+            Use this to prompt the user to touch their YubiKey. If not
+            provided, no notification is given when touch is needed.
 
     Returns:
         20-byte HMAC-SHA1 response wrapped in SecureBytes for automatic
@@ -145,7 +176,7 @@ def compute_challenge_response(
             was required but not received).
         YubiKeyError: For other YubiKey communication errors.
     """
-    if not YUBIKEY_AVAILABLE:
+    if not YUBIKEY_HARDWARE_AVAILABLE:
         raise YubiKeyNotAvailableError()
 
     if not challenge:
@@ -185,9 +216,19 @@ def compute_challenge_response(
         try:
             session = YubiOtpSession(connection)
 
-            # Calculate challenge response
-            # Note: yubikey-manager handles the timeout internally
-            response = session.calculate_hmac_sha1(slot, challenge)
+            # Set up keepalive handler to detect when touch is required
+            # The keepalive callback is invoked while waiting for the response,
+            # which happens when the YubiKey slot requires touch confirmation
+            touch_notified = False
+
+            def on_keepalive(_status: int) -> None:
+                nonlocal touch_notified
+                if not touch_notified and on_touch_required is not None:
+                    touch_notified = True
+                    on_touch_required()
+
+            # Calculate challenge response with touch detection
+            response = session.calculate_hmac_sha1(slot, challenge, on_keepalive=on_keepalive)
 
             return SecureBytes(bytes(response))
 
@@ -199,7 +240,7 @@ def compute_challenge_response(
 
         # Translate common errors to specific exceptions
         if "timeout" in error_msg or "timed out" in error_msg:
-            raise YubiKeyTimeoutError(config.timeout_seconds) from e
+            raise YubiKeyTimeoutError() from e
         if "not configured" in error_msg or "not programmed" in error_msg:
             raise YubiKeySlotError(config.slot) from e
         if "no device" in error_msg or "not found" in error_msg:
@@ -227,7 +268,7 @@ def check_slot_configured(slot: int = 2, serial: int | None = None) -> bool:
         YubiKeyNotAvailableError: If yubikey-manager is not installed.
         YubiKeyNotFoundError: If no YubiKey is connected (or specified serial not found).
     """
-    if not YUBIKEY_AVAILABLE:
+    if not YUBIKEY_HARDWARE_AVAILABLE:
         raise YubiKeyNotAvailableError()
 
     devices = list_all_devices()
@@ -261,3 +302,351 @@ def check_slot_configured(slot: int = 2, serial: int | None = None) -> bool:
 
     except Exception:
         return False
+
+
+# ============================================================================
+# Hardware YubiKey Provider
+# ============================================================================
+
+
+class HardwareYubiKey(ChallengeResponseProvider):
+    """Challenge-response provider using physical YubiKey hardware.
+
+    Uses the yubikey-manager library to communicate with a physical YubiKey
+    device for HMAC-SHA1 challenge-response authentication.
+
+    Requires:
+        - yubikey-manager package: pip install kdbxtool[yubikey]
+        - Physical YubiKey with HMAC-SHA1 configured in the specified slot
+
+    Example:
+        >>> from kdbxtool.security.yubikey import HardwareYubiKey
+        >>> provider = HardwareYubiKey(slot=2)
+        >>> db = Database.open("vault.kdbx", password="secret",
+        ...                    challenge_response_provider=provider)
+    """
+
+    def __init__(
+        self,
+        slot: int = 2,
+        serial: int | None = None,
+        on_touch_required: Callable[[], None] | None = None,
+    ) -> None:
+        """Initialize hardware YubiKey provider.
+
+        Args:
+            slot: YubiKey slot to use (1 or 2). Slot 2 is typically used for
+                challenge-response as slot 1 is often used for OTP.
+            serial: Optional serial number to select a specific YubiKey when
+                multiple devices are connected. If None, uses the first device.
+            on_touch_required: Optional callback invoked when YubiKey touch is
+                required. If None, uses the default touch callback which prints
+                to stderr.
+
+        Raises:
+            YubiKeyNotAvailableError: If yubikey-manager is not installed.
+            YubiKeyNotFoundError: If no YubiKey is connected (or specified serial not found).
+            ValueError: If slot is not 1 or 2.
+        """
+        if not YUBIKEY_HARDWARE_AVAILABLE:
+            raise YubiKeyNotAvailableError()
+        if slot not in (1, 2):
+            raise ValueError("YubiKey slot must be 1 or 2")
+
+        # Find and store the actual device
+        devices = list_all_devices()
+        if not devices:
+            raise YubiKeyNotFoundError()
+
+        # Select device by serial number if specified, otherwise use first device
+        device = None
+        info = None
+        if serial is not None:
+            for dev, dev_info in devices:
+                if dev_info.serial == serial:
+                    device = dev
+                    info = dev_info
+                    break
+            if device is None:
+                raise YubiKeyNotFoundError(
+                    f"No YubiKey with serial {serial} found. "
+                    f"Available serials: {[d[1].serial for d in devices if d[1].serial]}"
+                )
+        else:
+            device, info = devices[0]
+
+        self._slot = slot
+        self._device = device
+        self._device_info = info
+        self._on_touch_required = on_touch_required
+
+    @property
+    def slot(self) -> int:
+        """Return the slot number used by this provider."""
+        return self._slot
+
+    @property
+    def serial(self) -> int | None:
+        """Return the actual device serial number, or None if not available."""
+        return self._device_info.serial
+
+    def __repr__(self) -> str:
+        """Return string representation of the provider."""
+        serial_str = f"serial={self.serial}" if self.serial else "serial=None"
+        version = self._device_info.version
+        version_str = f"{version.major}.{version.minor}.{version.patch}"
+        return f"HardwareYubiKey(slot={self._slot}, {serial_str}, version={version_str})"
+
+    def _get_slot_enum(self) -> SLOT:
+        """Convert slot number to SLOT enum."""
+        return SLOT.ONE if self._slot == 1 else SLOT.TWO
+
+    def _open_session(self):
+        """Open a YubiOtpSession context manager."""
+        from contextlib import contextmanager
+
+        @contextmanager
+        def session_context():
+            connection = self._device.open_connection(OtpConnection)
+            try:
+                yield YubiOtpSession(connection)
+            finally:
+                connection.close()
+
+        return session_context()
+
+    def challenge_response(
+        self,
+        challenge: bytes,
+    ) -> SecureBytes:
+        """Compute HMAC-SHA1 response using the physical YubiKey.
+
+        Args:
+            challenge: Challenge bytes (e.g., 32-byte KDF salt)
+
+        Returns:
+            20-byte HMAC-SHA1 response wrapped in SecureBytes
+
+        Raises:
+            YubiKeySlotError: If slot is not configured for HMAC-SHA1
+            YubiKeyTimeoutError: If touch times out
+            YubiKeyError: For other communication errors
+        """
+        if not challenge:
+            raise ValueError("Challenge must not be empty")
+
+        slot_enum = self._get_slot_enum()
+
+        # Call the touch callback before attempting if one is set
+        if self._on_touch_required is not None:
+            self._on_touch_required()
+
+        try:
+            with self._open_session() as session:
+                response = session.calculate_hmac_sha1(slot_enum, challenge)
+                return SecureBytes(bytes(response))
+
+        except Exception as e:
+            error_msg = str(e).lower()
+
+            # Check if it's a timeout error
+            if isinstance(e, TimeoutError) or "timed out waiting for touch" in error_msg:
+                # Got a timeout - call callback and retry once
+                if self._on_touch_required is not None:
+                    self._on_touch_required()
+                else:
+                    DEFAULT_TOUCH_CALLBACK()
+
+                try:
+                    with self._open_session() as session:
+                        response = session.calculate_hmac_sha1(slot_enum, challenge)
+                        return SecureBytes(bytes(response))
+                except Exception as retry_e:
+                    retry_msg = str(retry_e).lower()
+                    if (
+                        isinstance(retry_e, TimeoutError)
+                        or "timed out waiting for touch" in retry_msg
+                    ):
+                        raise YubiKeyTimeoutError() from retry_e
+                    if "not configured" in retry_msg or "not programmed" in retry_msg:
+                        raise YubiKeySlotError(self._slot) from retry_e
+                    raise YubiKeyError(f"YubiKey challenge-response failed: {retry_e}") from retry_e
+
+            # Check for configuration errors
+            if "not configured" in error_msg or "not programmed" in error_msg:
+                raise YubiKeySlotError(self._slot) from e
+
+            # Generic error
+            raise YubiKeyError(f"YubiKey challenge-response failed: {e}") from e
+
+
+# ============================================================================
+# Mock YubiKey for Testing
+# ============================================================================
+
+
+class MockYubiKey(ChallengeResponseProvider):
+    """Mock challenge-response provider for testing without hardware.
+
+    Simulates YubiKey HMAC-SHA1 challenge-response using configurable secrets.
+    Useful for unit tests and CI environments where no YubiKey is available.
+
+    As a ChallengeResponseProvider, MockYubiKey can be passed directly to
+    Database.open(), Database.save(), etc. When used as a provider, it uses
+    the slot specified at construction time.
+
+    Default secrets match common test configurations:
+    - Slot 1: 20 zero bytes (0x00 * 20)
+    - Slot 2: "12345678901234567890" (20 bytes)
+
+    Example:
+        >>> from kdbxtool.security.yubikey import MockYubiKey
+        >>> # As a provider for Database operations
+        >>> provider = MockYubiKey.with_zero_secret(slot=1)
+        >>> db = Database.open("test.kdbx", password="test",
+        ...                    challenge_response_provider=provider)
+        >>>
+        >>> # Direct challenge-response (for testing)
+        >>> response = provider.challenge_response(b"test challenge")
+        >>> len(response.data)
+        20
+    """
+
+    # Common test secrets
+    ZERO_SECRET = b"\x00" * 20
+    TEST_NUMERIC_SECRET = b"12345678901234567890"
+
+    def __init__(
+        self,
+        slot: int = 2,
+        secret: bytes | None = None,
+        serial: int = 12345678,
+        simulate_touch: bool = False,
+    ) -> None:
+        """Initialize mock YubiKey provider.
+
+        Args:
+            slot: Slot number this provider represents (1 or 2).
+            secret: 20-byte HMAC secret. If None, uses ZERO_SECRET for slot 1
+                or NUMERIC_SECRET for slot 2.
+            serial: Simulated serial number for identification.
+            simulate_touch: Whether to call the touch callback during operations.
+
+        Raises:
+            ValueError: If slot is not 1 or 2, or secret is wrong length.
+        """
+        if slot not in (1, 2):
+            raise ValueError("Slot must be 1 or 2")
+
+        if secret is None:
+            secret = self.ZERO_SECRET if slot == 1 else self.TEST_NUMERIC_SECRET
+        elif len(secret) != 20:
+            raise ValueError("HMAC secret must be exactly 20 bytes")
+
+        self._slot = slot
+        self._secret = secret
+        self._serial = serial
+        self._simulate_touch = simulate_touch
+
+    @property
+    def slot(self) -> int:
+        """Return the slot number this provider represents."""
+        return self._slot
+
+    @property
+    def serial(self) -> int:
+        """Return the simulated serial number."""
+        return self._serial
+
+    @property
+    def secret(self) -> bytes:
+        """Return the HMAC secret (for testing inspection)."""
+        return self._secret
+
+    def __repr__(self) -> str:
+        """Return string representation of the mock provider."""
+        secret_desc = (
+            "ZERO_SECRET"
+            if self._secret == self.ZERO_SECRET
+            else "NUMERIC_SECRET"
+            if self._secret == self.TEST_NUMERIC_SECRET
+            else "custom"
+        )
+        touch_str = ", touch=True" if self._simulate_touch else ""
+        return (
+            f"MockYubiKey(slot={self._slot}, serial={self._serial}, "
+            f"secret={secret_desc}{touch_str})"
+        )
+
+    def challenge_response(
+        self,
+        challenge: bytes,
+    ) -> SecureBytes:
+        """Compute HMAC-SHA1 response using the configured secret.
+
+        Args:
+            challenge: Challenge bytes (e.g., 32-byte KDF salt)
+
+        Returns:
+            20-byte HMAC-SHA1 response wrapped in SecureBytes
+        """
+        import hashlib
+        import hmac
+
+        if self._simulate_touch:
+            DEFAULT_TOUCH_CALLBACK()
+
+        response = hmac.new(self._secret, challenge, hashlib.sha1).digest()
+        return SecureBytes(response)
+
+    @classmethod
+    def with_zero_secret(cls, slot: int = 1, simulate_touch: bool = False) -> MockYubiKey:
+        """Create a mock YubiKey with all-zeros secret on specified slot.
+
+        Args:
+            slot: Slot to configure with zero secret (default: 1)
+            simulate_touch: Whether to simulate touch requirement
+
+        Returns:
+            MockYubiKey instance
+        """
+        return cls(slot=slot, secret=cls.ZERO_SECRET, simulate_touch=simulate_touch)
+
+    @classmethod
+    def with_numeric_secret(
+        cls, secret: bytes, slot: int = 2, simulate_touch: bool = False
+    ) -> MockYubiKey:
+        """Create a mock YubiKey with a numeric/predictable secret on specified slot.
+
+        Unlike with_zero_secret(), this method requires you to explicitly pass
+        the secret bytes to make it clear that a specific predictable value
+        is being used.
+
+        Common test secret: MockYubiKey.TEST_NUMERIC_SECRET (b"12345678901234567890")
+
+        Args:
+            secret: 20-byte HMAC secret (e.g., MockYubiKey.TEST_NUMERIC_SECRET)
+            slot: Slot to configure (default: 2)
+            simulate_touch: Whether to simulate touch requirement
+
+        Returns:
+            MockYubiKey instance
+
+        Example:
+            >>> mock = MockYubiKey.with_numeric_secret(MockYubiKey.TEST_NUMERIC_SECRET, slot=2)
+        """
+        return cls(slot=slot, secret=secret, simulate_touch=simulate_touch)
+
+    @classmethod
+    def with_secret(cls, slot: int, secret: bytes, simulate_touch: bool = False) -> MockYubiKey:
+        """Create a mock YubiKey with a custom secret.
+
+        Args:
+            slot: Slot number (1 or 2)
+            secret: 20-byte HMAC secret
+            simulate_touch: Whether to simulate touch requirement
+
+        Returns:
+            MockYubiKey instance
+        """
+        return cls(slot=slot, secret=secret, simulate_touch=simulate_touch)

--- a/uv.lock
+++ b/uv.lock
@@ -507,7 +507,7 @@ wheels = [
 
 [[package]]
 name = "kdbxtool"
-version = "0.1.0"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },


### PR DESCRIPTION
Summary:
  - Adds challenge-response provider abstraction to enable pluggable authentication backends (hardware YubiKey, mock implementations, future smart cards, etc.) via the new ChallengeResponseProvider ABC
  - Implements MockYubiKey for testing YubiKey functionality without physical hardware, supporting both zero-secret (for basic testing) and custom secret configurations
  - Adds touch prompting for YubiKey operations that require physical touch, improving user experience during challenge-response authentication (library would previously hang without notice)
  - Improves error hierarchy by introducing ChallengeResponseError as base class with YubiKeyError as implementation-specific subclass
  - Enhances test coverage with comprehensive tests for both hardware (when available) and mock YubiKey scenarios (always)

Key Changes:
  - src/kdbxtool/security/challenge_response.py (new): Abstract base class for challenge-response authentication
  - src/kdbxtool/security/yubikey.py: Split into HardwareYubiKey and MockYubiKey classes
  - src/kdbxtool/database.py: Refactored to use provider interface instead of direct YubiKey parameters
  - src/kdbxtool/exceptions.py: Added ChallengeResponseError base class in hierarchy
  - tests/test_yubikey.py: Updated with extensive mock-based tests (allows testing without hardware)
  - tests/test_yubikey_hardware.py: Separated hardware-specific tests

Minor:
- Update __init__.py and uv versions to `0.1.5` to match github release version.
