### PR TITLE
Refactor tests to use to_bytes() instead of temp files

### DIFF
--- a/tests/test_cipher_config.py
+++ b/tests/test_cipher_config.py
@@ -1,6 +1,6 @@
 """Tests for cipher configuration on save."""
 
-import tempfile
+import warnings
 from pathlib import Path
 
 import pytest
@@ -16,34 +16,18 @@ class TestCipherConfigOnSave:
         db = Database.create(password="test")
         db.root_group.create_entry(title="Test")
 
-        with tempfile.NamedTemporaryFile(suffix=".kdbx", delete=False) as f:
-            filepath = Path(f.name)
-
-        try:
-            db.save(filepath=filepath, cipher=Cipher.CHACHA20)
-
-            # Verify we can reopen and cipher was changed
-            db2 = Database.open(filepath, password="test")
-            assert db2.find_entries(title="Test", first=True) is not None
-        finally:
-            filepath.unlink(missing_ok=True)
+        data = db.to_bytes(cipher=Cipher.CHACHA20)
+        db2 = Database.open_bytes(data, password="test")
+        assert db2.find_entries(title="Test", first=True) is not None
 
     def test_save_with_aes256(self) -> None:
         """Test saving with AES-256-CBC cipher."""
         db = Database.create(password="test")
         db.root_group.create_entry(title="Test")
 
-        with tempfile.NamedTemporaryFile(suffix=".kdbx", delete=False) as f:
-            filepath = Path(f.name)
-
-        try:
-            db.save(filepath=filepath, cipher=Cipher.AES256_CBC)
-
-            # Verify we can reopen
-            db2 = Database.open(filepath, password="test")
-            assert db2.find_entries(title="Test", first=True) is not None
-        finally:
-            filepath.unlink(missing_ok=True)
+        data = db.to_bytes(cipher=Cipher.AES256_CBC)
+        db2 = Database.open_bytes(data, password="test")
+        assert db2.find_entries(title="Test", first=True) is not None
 
     def test_to_bytes_with_chacha20(self) -> None:
         """Test to_bytes() with ChaCha20 cipher."""
@@ -51,8 +35,6 @@ class TestCipherConfigOnSave:
         db.root_group.create_entry(title="Test")
 
         data = db.to_bytes(cipher=Cipher.CHACHA20)
-
-        # Verify we can reopen from bytes
         db2 = Database.open_bytes(data, password="test")
         assert db2.find_entries(title="Test", first=True) is not None
 
@@ -68,45 +50,24 @@ class TestCipherConfigOnSave:
         )
         entry.set_custom_property("custom_key", "custom_value")
 
-        with tempfile.NamedTemporaryFile(suffix=".kdbx", delete=False) as f:
-            filepath = Path(f.name)
-
-        try:
-            # Save with different cipher
-            db.save(filepath=filepath, cipher=Cipher.CHACHA20)
-
-            # Reopen and verify all data
-            db2 = Database.open(filepath, password="test")
-            entry2 = db2.find_entries(title="Important", first=True)
-            assert entry2 is not None
-            assert entry2.username == "user@example.com"
-            assert entry2.password == "secret123"
-            assert entry2.url == "https://example.com"
-            assert entry2.notes == "Some notes here"
-            assert entry2.get_custom_property("custom_key") == "custom_value"
-        finally:
-            filepath.unlink(missing_ok=True)
+        data = db.to_bytes(cipher=Cipher.CHACHA20)
+        db2 = Database.open_bytes(data, password="test")
+        entry2 = db2.find_entries(title="Important", first=True)
+        assert entry2 is not None
+        assert entry2.username == "user@example.com"
+        assert entry2.password == "secret123"
+        assert entry2.url == "https://example.com"
+        assert entry2.notes == "Some notes here"
+        assert entry2.get_custom_property("custom_key") == "custom_value"
 
     def test_cipher_with_kdf_config(self) -> None:
         """Test using both cipher and kdf_config together."""
         db = Database.create(password="test")
         db.root_group.create_entry(title="Test")
 
-        with tempfile.NamedTemporaryFile(suffix=".kdbx", delete=False) as f:
-            filepath = Path(f.name)
-
-        try:
-            db.save(
-                filepath=filepath,
-                cipher=Cipher.CHACHA20,
-                kdf_config=Argon2Config.fast(),
-            )
-
-            # Verify we can reopen
-            db2 = Database.open(filepath, password="test")
-            assert db2.find_entries(title="Test", first=True) is not None
-        finally:
-            filepath.unlink(missing_ok=True)
+        data = db.to_bytes(cipher=Cipher.CHACHA20, kdf_config=Argon2Config.fast())
+        db2 = Database.open_bytes(data, password="test")
+        assert db2.find_entries(title="Test", first=True) is not None
 
 
 class TestCipherConfigOnUpgrade:
@@ -114,60 +75,31 @@ class TestCipherConfigOnUpgrade:
 
     def test_kdbx3_upgrade_with_chacha20(self) -> None:
         """Test KDBX3 upgrade with ChaCha20 cipher."""
-        import warnings
-
         test_file = Path(__file__).parent / "fixtures" / "test3.kdbx"
         test_key = Path(__file__).parent / "fixtures" / "test3.key"
+        keyfile_data = test_key.read_bytes()
 
-        with tempfile.NamedTemporaryFile(suffix=".kdbx", delete=False) as f:
-            temp_path = Path(f.name)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            db = Database.open(test_file, password="password", keyfile=test_key)
 
-        try:
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
-                db = Database.open(test_file, password="password", keyfile=test_key)
-
-            # Upgrade with ChaCha20 cipher
-            db.save(
-                filepath=temp_path,
-                allow_upgrade=True,
-                cipher=Cipher.CHACHA20,
-                kdf_config=Argon2Config.fast(),
-            )
-
-            # Verify the file was saved and can be reopened
-            db2 = Database.open(temp_path, password="password", keyfile=test_key)
-            assert db2.root_group is not None
-        finally:
-            temp_path.unlink(missing_ok=True)
+        data = db.to_bytes(cipher=Cipher.CHACHA20, kdf_config=Argon2Config.fast())
+        db2 = Database.open_bytes(data, password="password", keyfile_data=keyfile_data)
+        assert db2.root_group is not None
 
     def test_kdbx3_upgrade_preserves_default_cipher(self) -> None:
         """Test KDBX3 upgrade preserves original cipher if none specified."""
-        import warnings
-
         test_file = Path(__file__).parent / "fixtures" / "test3.kdbx"
         test_key = Path(__file__).parent / "fixtures" / "test3.key"
+        keyfile_data = test_key.read_bytes()
 
-        with tempfile.NamedTemporaryFile(suffix=".kdbx", delete=False) as f:
-            temp_path = Path(f.name)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            db = Database.open(test_file, password="password", keyfile=test_key)
 
-        try:
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
-                db = Database.open(test_file, password="password", keyfile=test_key)
-
-            # Upgrade without specifying cipher (should preserve existing)
-            db.save(
-                filepath=temp_path,
-                allow_upgrade=True,
-                kdf_config=Argon2Config.fast(),
-            )
-
-            # Verify file exists and can be opened
-            db2 = Database.open(temp_path, password="password", keyfile=test_key)
-            assert db2.root_group is not None
-        finally:
-            temp_path.unlink(missing_ok=True)
+        data = db.to_bytes(kdf_config=Argon2Config.fast())
+        db2 = Database.open_bytes(data, password="password", keyfile_data=keyfile_data)
+        assert db2.root_group is not None
 
 
 class TestCipherEnum:


### PR DESCRIPTION
## Summary
- Convert tests that don't need file-based operations to use `to_bytes()`/`open_bytes()` for in-memory roundtrips
- Remove tempfile imports where no longer needed
- Remove redundant file-based test in test_twofish.py that duplicated `test_to_bytes_roundtrip`

## Files Changed
- **test_kdf_config.py**: All KDBX3 upgrade and KDF config tests converted
- **test_cipher_config.py**: All cipher config tests converted
- **test_field_references.py**: `test_reference_survives_save_reload` converted
- **test_twofish.py**: Removed `test_create_save_reopen` (redundant with `test_to_bytes_roundtrip`), converted `test_modify_and_resave`

## Tests Retained with tempfile
Tests that explicitly verify file I/O behavior retain tempfile usage:
- `test_reload.py` - Tests `reload()` which requires actual files
- `test_database.py` - Tests `save()`/`open()` and `open_interactive()`
- `test_xml_export.py` - Tests `dump_xml()` which writes files
- `test_keyfile.py` - Tests `create_keyfile()` which creates files
- `test_kdbx3.py` - Tests `allow_upgrade` flag on file save

## Test plan
- [x] All converted tests pass (67 passed, 1 skipped)
- [x] Net reduction of 207 lines

Closes #67