### PR TITLE
feat: add structured debug logging for troubleshooting

### DIFF
--- a/src/kdbxtool/__init__.py
+++ b/src/kdbxtool/__init__.py
@@ -25,12 +25,6 @@ Example:
 import logging
 from importlib.metadata import version
 
-__version__ = version("kdbxtool")
-
-# Configure library logger to prevent "No handler found" warnings
-# when users don't configure logging in their applications
-logging.getLogger("kdbxtool").addHandler(logging.NullHandler())
-
 from .database import Database, DatabaseSettings
 from .exceptions import (
     AuthenticationError,
@@ -75,6 +69,12 @@ from .security.yubikey import (
     list_yubikeys,
 )
 from .templates import EntryTemplate, IconId, Templates
+
+__version__ = version("kdbxtool")
+
+# Configure library logger to prevent "No handler found" warnings
+# when users don't configure logging in their applications
+logging.getLogger("kdbxtool").addHandler(logging.NullHandler())
 
 __all__ = [
     # Core classes

--- a/src/kdbxtool/__init__.py
+++ b/src/kdbxtool/__init__.py
@@ -22,9 +22,14 @@ Example:
     db.save()
 """
 
+import logging
 from importlib.metadata import version
 
 __version__ = version("kdbxtool")
+
+# Configure library logger to prevent "No handler found" warnings
+# when users don't configure logging in their applications
+logging.getLogger("kdbxtool").addHandler(logging.NullHandler())
 
 from .database import Database, DatabaseSettings
 from .exceptions import (

--- a/src/kdbxtool/database.py
+++ b/src/kdbxtool/database.py
@@ -624,8 +624,8 @@ class Database:
         logger.info("Database opened successfully")
         logger.debug(
             "Loaded %d entries, %d groups",
-            len(db.find_entries()),
-            len(db.find_groups()),
+            len(cast(list[Entry], db.find_entries())),
+            len(cast(list[Group], db.find_groups())),
         )
 
         return db

--- a/src/kdbxtool/security/crypto.py
+++ b/src/kdbxtool/security/crypto.py
@@ -11,6 +11,7 @@ All cryptographic operations use well-audited libraries (PyCryptodome).
 from __future__ import annotations
 
 import hmac
+import logging
 import os
 from enum import Enum
 from typing import TYPE_CHECKING
@@ -30,6 +31,8 @@ except ImportError:
 
 if TYPE_CHECKING:
     pass
+
+logger = logging.getLogger(__name__)
 
 
 class Cipher(Enum):
@@ -184,6 +187,7 @@ class CipherContext:
         self._cipher = cipher
         self._key = key
         self._iv = iv
+        logger.debug("Cipher initialized: %s", cipher.display_name)
 
     def encrypt(self, plaintext: bytes) -> bytes:
         """Encrypt plaintext data.

--- a/src/kdbxtool/security/yubikey.py
+++ b/src/kdbxtool/security/yubikey.py
@@ -27,6 +27,7 @@ Security Notes:
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -56,6 +57,7 @@ except ImportError:
 if TYPE_CHECKING:
     pass
 
+logger = logging.getLogger(__name__)
 
 # HMAC-SHA1 response is always 20 bytes
 HMAC_SHA1_RESPONSE_SIZE = 20
@@ -113,6 +115,7 @@ def list_yubikeys() -> list[dict[str, str | int]]:
             device_info["serial"] = info.serial
         devices.append(device_info)
 
+    logger.debug("Found %d YubiKey devices", len(devices))
     return devices
 
 
@@ -178,6 +181,7 @@ def compute_challenge_response(
 
     # Convert slot number to SLOT enum
     slot = SLOT.ONE if config.slot == 1 else SLOT.TWO
+    logger.debug("Starting YubiKey challenge-response on slot %d", config.slot)
 
     try:
         # Connect via smartcard interface for challenge-response
@@ -189,6 +193,7 @@ def compute_challenge_response(
             # Note: yubikey-manager handles the timeout internally
             response = session.calculate_hmac_sha1(slot, challenge)
 
+            logger.debug("YubiKey challenge-response complete")
             return SecureBytes(bytes(response))
 
         finally:


### PR DESCRIPTION
## Summary

- Add structured debug logging throughout kdbxtool for troubleshooting
- Follow Python library best practices (NullHandler, `logging.getLogger(__name__)`)
- Never log sensitive data (passwords, keys, decrypted content)

## Changes

| File | Logging Added |
|------|---------------|
| `__init__.py` | NullHandler to prevent warnings |
| `parsing/header.py` | Version, cipher, compression, KDF params |
| `parsing/kdbx4.py` | Decryption/encryption progress, HMAC verification |
| `parsing/kdbx3.py` | Decryption progress, block verification |
| `security/kdf.py` | KDF start/complete, composite key (booleans only) |
| `security/crypto.py` | Cipher initialization |
| `security/keyfile.py` | Format detection, keyfile creation |
| `security/yubikey.py` | Device count, challenge-response |
| `database.py` | Open/save/create/reload, entry/group counts |

## Usage

```python
import logging
logging.basicConfig(level=logging.DEBUG)

from kdbxtool import Database
db = Database.open("test.kdbx", password="test")
```

## Test plan

- [x] All 706 tests pass
- [x] Verified no sensitive data is logged (passwords, keys, salts, decrypted content)
- [x] NullHandler prevents warnings when logging not configured

Closes #29